### PR TITLE
Use 8-bit serial frames for binary payload

### DIFF
--- a/SerialReader/src/Main.cpp
+++ b/SerialReader/src/Main.cpp
@@ -14,7 +14,10 @@ const int halfJoystickValue = maxJoystickValue / 2;
 int main() {
     const char* port = "\\\\.\\COM3";
     DWORD baudRate = CBR_57600;
-    int ByteSize = 5;
+    // Configure the serial port to use 8 data bits. The previous value of 5
+    // caused the OS to truncate every byte coming from the Arduino which
+    // resulted in malformed frames and unreadable binary data.
+    int ByteSize = 8;
     SerialConnection ArduinoConnection(port, baudRate, ByteSize);
 
 


### PR DESCRIPTION
## Summary
- Configure SerialReader to open the COM port with 8 data bits so binary frames from the Arduino are read intact.

## Testing
- `g++ -std=c++17 -Ishared/include -ISerialReader/include SerialReader/src/Main.cpp SerialReader/src/SerialConnection.cpp -o serialreader` *(fails: windows.h: No such file or directory)*
- `apt-get update` *(fails: repository 403 forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689c15838bbc8321a2840a3942ee515b